### PR TITLE
Update temp tables to use "text" as column type for strings

### DIFF
--- a/lib/etl/output/sequel.rb
+++ b/lib/etl/output/sequel.rb
@@ -49,7 +49,7 @@ module ETL::Output
     def col_type_str(col)
       case col.type
         when :string
-          "varchar(255)"
+          "text"
         when :date
           "timestamp"
         when :numeric


### PR DESCRIPTION
Cherry-pick of commit(s) existing in `getoutreach`'s fork.