### PR TITLE
Update tests to run out of the box

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,9 +3,6 @@ PATH
   specs:
     etl (0.1.0)
       clamp
-      influxdb
-      mysql2
-      pg
       sequel
       tzinfo
       tzinfo-data
@@ -23,7 +20,7 @@ GEM
     bunny (2.3.0)
       amq-protocol (>= 2.0.1)
     cause (0.1)
-    clamp (1.0.0)
+    clamp (1.1.1)
     diff-lcs (1.2.5)
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
@@ -45,7 +42,8 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
-    sequel (4.32.0)
+    sequel (4.35.0)
+    sqlite3 (1.3.13)
     thread_safe (0.3.4)
     time-warp (1.0.15)
     tzinfo (1.2.2)
@@ -61,10 +59,14 @@ DEPENDENCIES
   etl!
   factory_girl
   forgery
+  influxdb
+  mysql2
+  pg
   rspec-core
   rspec-expectations
   rspec-mocks
+  sqlite3
   time-warp
 
 BUNDLED WITH
-   1.11.2
+   1.14.6

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,2 @@
+dw_test*
+test*

--- a/etl.gemspec
+++ b/etl.gemspec
@@ -19,12 +19,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'clamp'
-  spec.add_dependency 'mysql2'
   spec.add_dependency 'sequel'
   spec.add_dependency 'tzinfo'
   spec.add_dependency 'tzinfo-data'
-  spec.add_dependency 'influxdb'
-  spec.add_dependency 'pg'
 
   spec.add_development_dependency 'bunny'
   spec.add_development_dependency 'factory_girl'
@@ -33,4 +30,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-expectations'
   spec.add_development_dependency 'rspec-mocks'
   spec.add_development_dependency 'time-warp'
+  spec.add_development_dependency 'mysql2'
+  spec.add_development_dependency 'influxdb'
+  spec.add_development_dependency 'pg'
+  spec.add_development_dependency 'sqlite3'
 end

--- a/lib/etl.rb
+++ b/lib/etl.rb
@@ -3,12 +3,14 @@ module ETL
   def ETL.root
     File.expand_path('../..', __FILE__)
   end
+  
+  # Loads in the remaining ETL-related files. This should be called after
+  # the ETL system is configured.
+  def ETL.bootstrap
+    # Include the rest of code needed for ETL system
+    require 'etl/core'
+  end
 end
-
-$LOAD_PATH.unshift(ETL.root + "/lib")
 
 # Process our configuration files
 require 'etl/config'
-    
-# Include the rest of code needed for ETL system
-require 'etl/core'

--- a/lib/etl/batch_factory/time.rb
+++ b/lib/etl/batch_factory/time.rb
@@ -1,5 +1,5 @@
 require 'tzinfo'
-require 'util/time_util'
+require 'etl/util/time_util'
 
 module ETL::BatchFactory
   

--- a/lib/etl/config.rb
+++ b/lib/etl/config.rb
@@ -42,4 +42,8 @@ module ETL
   def self.config
     Config.instance
   end
+  
+  def ETL.configure
+    yield ETL.config
+  end
 end

--- a/lib/etl/config.rb
+++ b/lib/etl/config.rb
@@ -35,7 +35,11 @@ module ETL
     end
     
     def self.load_file(file)
-      ETL::HashUtil::symbolize_keys(Psych.load_file(file))
+      if File.exist?(file)
+        ETL::HashUtil::symbolize_keys(Psych.load_file(file)) 
+      else
+        {}
+      end
     end
   end
   

--- a/lib/etl/config.rb
+++ b/lib/etl/config.rb
@@ -36,7 +36,7 @@ module ETL
     
     def self.load_file(file)
       if File.exist?(file)
-        ETL::HashUtil::symbolize_keys(Psych.load_file(file)) 
+        ETL::HashUtil::symbolize_keys(Psych.load_file(file)) || {}
       else
         {}
       end

--- a/lib/etl/core.rb
+++ b/lib/etl/core.rb
@@ -1,6 +1,3 @@
-libdir = File.expand_path("..", __FILE__)
-$LOAD_PATH.unshift(libdir)
-
 # Pre-define the module so we can use simpler syntax
 module ETL
 end
@@ -19,7 +16,7 @@ require 'etl/batch'
 # Models
 # Set up the database connection that's needed for Sequel models
 # Also we can use the DB constant in the rest of the code
-DB = Sequel::Model.db = Sequel.connect(ETL.config.core[:database])
+Sequel::Model.db = Sequel.connect(ETL.config.core[:database])
 Sequel::Model.plugin :timestamps
 require 'etl/models/job_run'
 
@@ -30,6 +27,7 @@ require 'etl/job/result'
 require 'etl/job/base'
 require 'etl/job/manager'
 
+libdir = File.expand_path("..", __FILE__)
 base_file = 'base.rb'
 %w( input output transform queue batch_factory schedule ).each do |d|
   dir = "#{libdir}/#{d}"

--- a/lib/etl/input/base.rb
+++ b/lib/etl/input/base.rb
@@ -1,4 +1,4 @@
-require 'mixins/cached_logger'
+require 'etl/mixins/cached_logger'
 
 module ETL::Input
   class Base

--- a/lib/etl/job/base.rb
+++ b/lib/etl/job/base.rb
@@ -1,4 +1,4 @@
-require 'mixins/cached_logger'
+require 'etl/mixins/cached_logger'
 
 module ETL::Job
 

--- a/lib/etl/job/schema.rb
+++ b/lib/etl/job/schema.rb
@@ -1,0 +1,36 @@
+# Class for creating and destroying the schema needed to manage the jobs
+module ETL::Job
+  class Schema
+    
+    def initialize(con)
+      @con = con
+    end
+    
+    def exist?
+      @con.tables.length > 0
+    end
+    
+    def create
+      raise "Tables already exist" if exist?
+      @con.create_table(:job_runs) do
+        primary_key :id
+        DateTime :created_at, null: false
+        DateTime :updated_at, null: false
+        String :job_id, :null => false, :index => true
+        String :batch, :null => false, :index => true
+        String :status, :null => false, :index => true
+        DateTime :queued_at
+        DateTime :started_at
+        DateTime :ended_at
+        Integer :rows_processed
+        String :message
+      end
+    end
+    
+    def destroy
+      @con.tables.each do |t|
+        @con.drop_table(t)
+      end
+    end
+  end
+end

--- a/lib/etl/output/base.rb
+++ b/lib/etl/output/base.rb
@@ -1,4 +1,4 @@
-require 'mixins/cached_logger'
+require 'etl/mixins/cached_logger'
 
 module ETL::Output
 

--- a/lib/etl/schedule/base.rb
+++ b/lib/etl/schedule/base.rb
@@ -1,4 +1,4 @@
-require 'models/job_run'
+require 'etl/models/job_run'
 
 module ETL::Schedule
   

--- a/spec/etc/core.yml
+++ b/spec/etc/core.yml
@@ -1,0 +1,21 @@
+job:
+  data_dir: "data"
+  class_dir: "spec/lib/jobs"
+  retry_max: 5 # maximum times retrying jobs
+  retry_wait: 4 # seconds
+  retry_mult: 2.0 # exponential backoff multiplier
+
+# logging class that we use
+log:
+  class: ETL::Logger
+  file: "log/test.log"
+  level: info
+
+# connection info for database where we store jobs history
+database:
+  adapter: sqlite
+  database: "data/dw_test.sqlite"
+
+# connection info for jobs queue
+queue:
+  class: ETL::Queue::File

--- a/spec/etc/core.yml
+++ b/spec/etc/core.yml
@@ -14,7 +14,7 @@ log:
 # connection info for database where we store jobs history
 database:
   adapter: sqlite
-  database: "data/dw_test.sqlite"
+  database: "data/dw_test.db"
 
 # connection info for jobs queue
 queue:

--- a/spec/etc/database.yml
+++ b/spec/etc/database.yml
@@ -1,0 +1,22 @@
+## Database connections for running the rspec test suite
+## Uncomment the below and fill them in with valid connection details to
+## run the full suite.
+# test:
+#   adapter: postgresql
+#   encoding: utf8
+#   reconnect: false
+#   database: db_name
+#   pool: 5
+#   username: rw_user
+#   password: 'password'
+#   host: 127.0.0.1
+# 
+# test_mysql:
+#   adapter: mysql
+#   encoding: utf8
+#   reconnect: false
+#   database: db_name
+#   pool: 5
+#   username: rw_user
+#   password: 'password'
+#   host: 127.0.0.1

--- a/spec/etc/jobs.yml
+++ b/spec/etc/jobs.yml
@@ -1,3 +1,2 @@
 csv_to_csv:
   class: ETL::Test::CsvToCsv
-

--- a/spec/input/influxdb_spec.rb
+++ b/spec/input/influxdb_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "influxdb inputs" do
   let(:series) { 'input_test' }
   
   before do
+    skip "Missing InfluxDB config" unless dbconfig
     c = idb.conn
     
     data = [

--- a/spec/input/sequel_spec.rb
+++ b/spec/input/sequel_spec.rb
@@ -4,15 +4,20 @@ require 'etl/core'
 
 
 RSpec.describe "sequel inputs" do
-  it "mysql input each" do
-    # add data to the test db
-    dbconfig = ETL.config.db[:test_mysql]
-    client = Mysql2::Client.new(
+  let(:dbconfig) { ETL.config.db[:test_mysql] }
+  let(:client) { Mysql2::Client.new(
       :host => dbconfig[:host],
       :database => dbconfig[:database],
       :username => dbconfig[:username],
       :password => dbconfig[:password],
       :flags => Mysql2::Client::MULTI_STATEMENTS)
+  }
+  
+  before do
+    skip "Missing MySQL config" unless dbconfig
+  end
+  
+  it "mysql input each" do
     
     table_name = "test_table"
     

--- a/spec/output/csv_spec.rb
+++ b/spec/output/csv_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "csv output" do
   it "csv - overwrite" do
 
     # remove old file
-    outfile = "/var/tmp/etl_test_output/test_1/20150331.csv"
+    outfile = "data/test_1/20150331.csv"
     File.delete(outfile) if File.exist?(outfile)
     expect(File.exist?(outfile)).to be false
 
@@ -106,7 +106,7 @@ END
   it "csv - append" do
 
     # remove old file
-    outfile = "/var/tmp/etl_test_output/test_1/20150331.csv"
+    outfile = "data/test_1/20150331.csv"
     File.delete(outfile) if File.exist?(outfile)
     expect(File.exist?(outfile)).to be false
 
@@ -166,7 +166,7 @@ END
   it "psv - overwrite" do
 
     # remove old file
-    outfile = "/var/tmp/etl_test_output/test_2/20150331.csv"
+    outfile = "data/test_2/20150331.csv"
     File.delete(outfile) if File.exist?(outfile)
     expect(File.exist?(outfile)).to be false
     # file does not have headers

--- a/spec/output/influxdb_spec.rb
+++ b/spec/output/influxdb_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe "influxdb output" do
     ETL::Input::Array.new(data)
   }
   
+  before do
+    skip "Missing InfluxDB config" unless dbconfig
+  end
+  
   describe 'is_numeric' do
     {
       1 => true,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,13 +54,15 @@ require 'etl'
 ETL.configure do |config|
   # Update config path to be our rspec directory
   config.config_dir = File.expand_path("../etc", __FILE__)
+end
 
-  # ETL system configuration
-  config.core do |c|
-    # override to write logs to file so they don't clutter up STDOUT
-    c[:log][:file] = "#{ETL.root}/log/test.log"
-    c[:class_dir] = "#{ETL.root}/spec/lib/jobs" # rspec jobs
-  end
+# Recreate the jobs database
+require 'sequel'
+require 'etl/job/schema'
+Sequel.connect(ETL.config.core[:database]) do |conn|
+  schema = ETL::Job::Schema.new(conn)
+  schema.destroy
+  schema.create
 end
 
 # Load in rest of ETL system

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-require 'etl'
 require 'factory_girl'
 require 'time_warp'
 
@@ -50,23 +49,19 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 end
 
-# ETL system configuration
-ETL.config.core do |c|
-  # override to write logs to file so they don't clutter up STDOUT
-  unless c[:log][:file]
-    f = "log/test.log"
-    puts("Writing rspec output to #{f}")
-    c[:log][:file] = f
+# Configure our ETL system
+require 'etl'
+ETL.configure do |config|
+  # Update config path to be our rspec directory
+  config.config_dir = File.expand_path("../etc", __FILE__)
+
+  # ETL system configuration
+  config.core do |c|
+    # override to write logs to file so they don't clutter up STDOUT
+    c[:log][:file] = "#{ETL.root}/log/test.log"
+    c[:class_dir] = "#{ETL.root}/spec/lib/jobs" # rspec jobs
   end
 end
 
-# Libraries in ETL rspec directory
-libdir = File.expand_path("../lib", __FILE__)
-$LOAD_PATH.unshift(libdir)
-%w( jobs ).each do |d|
-  dir = "#{libdir}/#{d}"
-  Dir.new(dir).each do |file|
-    next unless file =~ /\.rb$/
-    require "#{dir}/#{file}"
-  end
-end
+# Load in rest of ETL system
+ETL.bootstrap

--- a/spec/util/time_util_spec.rb
+++ b/spec/util/time_util_spec.rb
@@ -1,4 +1,4 @@
-require 'util/time_util'
+require 'etl/util/time_util'
 
 RSpec.describe "time_util" do
 


### PR DESCRIPTION
Simplify ETL system configuration so that we don't need to modify the library load path and we can easily set up configuration for rspec to work out of the box. Skip tests that won't run if the database configuration isn't set up.

